### PR TITLE
fix: changed php version for style to 8.1, add permissions for action

### DIFF
--- a/.github/workflows/fix_style.yml
+++ b/.github/workflows/fix_style.yml
@@ -8,27 +8,33 @@ jobs:
   style:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.1
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-8.2-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-8.1-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.2
+            ${{ runner.os }}-php-8.1
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer install
           composer dump
+
       - name: Fix styles
         run: vendor/bin/php-cs-fixer fix
 


### PR DESCRIPTION
- Changed php-cs-fixer version to 8.1, so it doesn't complain, maybe it's better to use the environment variable the error states?
![imagen](https://user-images.githubusercontent.com/76071376/217909272-f7adbc4a-2a1f-43bf-b7ae-b93207ef57f9.png)

- Added permissions to action so it doesn't need action secrets.